### PR TITLE
Install python requirements

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -4,8 +4,9 @@ USER root
 
 # Install pip dependencies
 RUN yum install -y python3-pip
-RUN pip install ansible
-RUN ansible-galaxy collection install kubernetes.core community.general -U
+COPY requirements.txt requirements.yaml /tmp/
+RUN pip install -r /tmp/requirements.txt
+RUN ansible-galaxy install -r /tmp/requirements.yaml
 
 ENV \
     GECOS="Keycloak user" \

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+ansible
+kubernetes
+netaddr

--- a/requirements.yaml
+++ b/requirements.yaml
@@ -1,0 +1,3 @@
+collections:
+- community.general
+- kubernetes.core


### PR DESCRIPTION
The `kubernetes.core` collection [1] requiremes the `kubernetes` python
module in order to function. The ansible `ipaddr` filter, which is often
useful,  requires the `netaddr` module.

This commit adds a `requirements.txt` file to handle Python requirements,
and moves ansible dependencies into `requirements.yaml`.

Closes: #1

[1]: https://docs.ansible.com/ansible/latest/collections/kubernetes/core/index.html
